### PR TITLE
DD-757 Tester å overskrive version for reststop-core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,6 +26,10 @@
 
     <artifactId>reststop-core</artifactId>
 
+    <build>
+        <finalName>reststop-core-${reststop.version}</finalName>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Ved å legge til finalName med innsendt reststop.version i pom.xml i modulen reststop-core. For å sjekke om det hjelper for å få publisert submodule med korrekt versjon fra release.