### PR TITLE
DD-757 bruk revision for å sette korrekt version ved deploy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,12 +20,12 @@ jobs:
       - name: Build Maven project
         run: |
           if [ -n "${{ env.RELEASE_TAG }}" ]; then
-            mvn --batch-mode package -Dreststop.version="${{ env.RELEASE_TAG }}"
+            mvn --batch-mode package -Drevision="${{ env.RELEASE_TAG }}"
           else
             mvn --batch-mode package
           fi
       - name: Publish package
         if: github.event_name == 'release'
-        run: mvn --batch-mode deploy -Dreststop.version="${{ env.RELEASE_TAG }}"
+        run: mvn --batch-mode deploy -Drevision="${{ env.RELEASE_TAG }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/annotation-processor/pom.xml
+++ b/annotation-processor/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-parent</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>reststop-annotation-processor</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-parent</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>reststop-api</artifactId>
 </project>

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-parent</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>reststop-bootstrap</artifactId>

--- a/classloader-utils/pom.xml
+++ b/classloader-utils/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-parent</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>reststop-classloader-utils</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-parent</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>reststop-core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,10 +26,6 @@
 
     <artifactId>reststop-core</artifactId>
 
-    <build>
-        <finalName>reststop-core-${reststop.version}</finalName>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/integration-tests/custom-app/api/pom.xml
+++ b/integration-tests/custom-app/api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-custom-app</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>reststop-custom-app-api</artifactId>
     <packaging>jar</packaging>

--- a/integration-tests/custom-app/french-greeting-plugin/pom.xml
+++ b/integration-tests/custom-app/french-greeting-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-custom-app</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>reststop-custom-app-french</artifactId>
     <packaging>jar</packaging>

--- a/integration-tests/custom-app/german-greeting-plugin/pom.xml
+++ b/integration-tests/custom-app/german-greeting-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-custom-app</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>reststop-custom-app-german</artifactId>
     <packaging>jar</packaging>

--- a/integration-tests/custom-app/pom.xml
+++ b/integration-tests/custom-app/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-parent</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>reststop-custom-app</artifactId>

--- a/integration-tests/custom-app/webapp/pom.xml
+++ b/integration-tests/custom-app/webapp/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-custom-app</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>reststop-custom-app-webapp</artifactId>
     <packaging>war</packaging>

--- a/integration-tests/hello-world/pom.xml
+++ b/integration-tests/hello-world/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-parent</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-parent</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>reststop-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/plugins/assets/pom.xml
+++ b/plugins/assets/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/cxf-logging/pom.xml
+++ b/plugins/cxf-logging/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/cxf-metrics/pom.xml
+++ b/plugins/cxf-metrics/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/cxf/pom.xml
+++ b/plugins/cxf/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/development-console/pom.xml
+++ b/plugins/development-console/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/development/pom.xml
+++ b/plugins/development/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/jaxrs-api/pom.xml
+++ b/plugins/jaxrs-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/jaxrs-metrics/pom.xml
+++ b/plugins/jaxrs-metrics/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/jaxws-api/pom.xml
+++ b/plugins/jaxws-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/jersey/pom.xml
+++ b/plugins/jersey/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/jetty-websockets/pom.xml
+++ b/plugins/jetty-websockets/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/jetty/pom.xml
+++ b/plugins/jetty/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/metrics-servlets/pom.xml
+++ b/plugins/metrics-servlets/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/metrics/pom.xml
+++ b/plugins/metrics/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-parent</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>reststop-plugins</artifactId>

--- a/plugins/security/pom.xml
+++ b/plugins/security/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/servlet-deploy/pom.xml
+++ b/plugins/servlet-deploy/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/springmvc/pom.xml
+++ b/plugins/springmvc/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/statistics/pom.xml
+++ b/plugins/statistics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/webjars/pom.xml
+++ b/plugins/webjars/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/wicket/pom.xml
+++ b/plugins/wicket/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugins/wsdl-test/pom.xml
+++ b/plugins/wsdl-test/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-plugins</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.kantega.reststop</groupId>
     <artifactId>reststop-parent</artifactId>
-    <version>3.12-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <name>Reststop</name>
@@ -54,7 +54,7 @@
 
 
     <properties>
-        <reststop.version>3.12-SNAPSHOT</reststop.version>
+        <revision>3.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jersey.version>2.25</jersey.version>
         <jetty.version>9.3.25.v20180904</jetty.version><!-- Also defined in template-plugin-webapp-pom.xml -->
@@ -209,7 +209,6 @@
     </dependencyManagement>
 
     <build>
-        <finalName>reststop-${reststop.version}</finalName>
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/servlet-api/pom.xml
+++ b/servlet-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-parent</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>reststop-servlet-api</artifactId>
 

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-parent</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>reststop-servlet</artifactId>
 

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kantega.reststop</groupId>
         <artifactId>reststop-parent</artifactId>
-        <version>3.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>reststop-webapp</artifactId>
     <packaging>war</packaging>


### PR DESCRIPTION
Slik at man kan bruke release versions uten å måtte endre pom.xml ved hver ny release-versjon