### PR TITLE
DD-757 Bundle sources med jar

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
           if [ -n "${{ env.RELEASE_TAG }}" ]; then
             ./mvnw --batch-mode package -Drevision="${{ env.RELEASE_TAG }}"
           else
-            ./mvnw --batch-mode package
+            ./mvnw --batch-mode source:jar package
           fi
       - name: Publish package
         if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/master')

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <jakarta-servlet.version>6.0.0</jakarta-servlet.version><!-- Also defined in template-plugin-plugins-pom.xml -->
         <jakarta-annotation.version>3.0.0</jakarta-annotation.version>
         <jakarta-validation.version>3.0.2</jakarta-validation.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     </properties>
 
     <modules>
@@ -242,6 +243,19 @@
                         <phase>clean</phase>
                         <goals>
                             <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Bundler sources med jar ved opplasting av pakker til maven repo. For å kunne debugge og gå inn i klassene til Reststop når man debugger andre applikasjoner som har installert pakker fra Reststop. Installerer maven-source-plugin:3.2.1 for å kunne kjøre mvn source:jar.