### PR TITLE
NVDB-16603 - Update deps

### DIFF
--- a/integration-tests/hello-world/pom.xml
+++ b/integration-tests/hello-world/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.4</version>
+            <version>${commons-io.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-invoker</artifactId>
-            <version>2.2</version>
+            <version>3.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -102,17 +102,17 @@
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.9.2</version>
+            <version>1.10.15</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.4</version>
+            <version>${commons-io.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.3.2</version>
+            <version>3.20.0</version>
         </dependency>
         <dependency>
             <groupId>org.twdata.maven</groupId>
@@ -127,12 +127,12 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>5.1.3.201810200350-r</version>
+            <version>7.2.1.202505142326-r</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/maven-plugin/src/main/resources/no/vegvesen/nvdb/reststop/maven/dist/template-plugin-webapp-pom.xml
+++ b/maven-plugin/src/main/resources/no/vegvesen/nvdb/reststop/maven/dist/template-plugin-webapp-pom.xml
@@ -133,7 +133,7 @@
             <plugin>
                 <groupId>org.eclipse.jetty.ee10</groupId>
                 <artifactId>jetty-ee10-maven-plugin</artifactId>
-                <version>12.0.10</version>
+                <version>12.1.6</version>
                 <configuration>
                     <systemProperties>
                         <reststopPort>${reststopPort}</reststopPort>

--- a/plugins/cxf/pom.xml
+++ b/plugins/cxf/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>reststop-cxf-plugin</artifactId>
 
     <properties>
-        <cxf.version>4.0.4</cxf.version>
+        <cxf.version>4.1.4</cxf.version>
     </properties>
 
     <dependencies>

--- a/plugins/development/pom.xml
+++ b/plugins/development/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>${commons-io.version}</version>
         </dependency>
 
     </dependencies>

--- a/plugins/springmvc/pom.xml
+++ b/plugins/springmvc/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>6.1.7</version>
+            <version>6.2.16</version>
         </dependency>
     </dependencies>
 </project>

--- a/plugins/wicket/pom.xml
+++ b/plugins/wicket/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.apache.wicket</groupId>
             <artifactId>wicket-core</artifactId>
-            <version>10.0.0</version>
+            <version>10.8.0</version>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,17 +44,19 @@
     <properties>
         <revision>4.0.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jersey.version>3.1.7</jersey.version>
-        <jetty.version>12.0.10</jetty.version><!-- Also defined in template-plugin-webapp-pom.xml -->
+        <jersey.version>3.1.11</jersey.version>
+        <jetty.version>12.1.6</jetty.version><!-- Also defined in template-plugin-webapp-pom.xml -->
         <maven.version>3.9.6</maven.version>
         <maven-deploy-plugin.version>3.1.2</maven-deploy-plugin.version>
-        <aether.version>1.0.0.v20140518</aether.version>
+        <aether.version>1.1.0</aether.version>
         <jexmec.version>2.0.0rc8</jexmec.version>
-        <logback.version>1.1.2</logback.version>
-        <slf4j.version>1.7.7</slf4j.version>
+        <logback.version>1.5.29</logback.version>
+        <slf4j.version>2.0.17</slf4j.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <tomcat.version>10.1.24</tomcat.version>
         <jaxb.version>4.0.5</jaxb.version>
+        <junit.version>4.13.2</junit.version>
+        <commons-io.version>2.21.0</commons-io.version>
         <!-- Versions taken from jakartaee-bom -->
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
         <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
@@ -179,7 +181,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>1.4</version>
+                <version>${commons-io.version}</version>
             </dependency>
 
             <dependency>
@@ -199,7 +201,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.11</version>
+                <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
```
pom.xml
   added properties:
	- commons-io.version        1.4     -> 2.21.0
	- junit.version             4.11    -> 4.13.2

   changed versions:
	- jersey.version            3.1.7   -> 3.1.11
	- slf4j.version             1.7.7   -> 2.0.17
	- logback.version           1.1.2   -> 1.5.29
	- aether.version            1.0.0*  -> 1.1.0

reststop-maven-plugin/pom.xml
    changed versions:
        jetty-ee10-maven-plugin     12.0.10 -> 12.1.6
        jetty-ee10-webapp           12.0.10 -> 12.1.6
        ant                         1.9.2   -> 1.10.15
        commons-lang3               3.3.2   -> 3.20.0
        commons-io                  1.4     -> 2.21.0
        org.eclipse.jgit            5.1.3   -> 7.2.1
        maven-invoker               2.2     -> 3.3.0

plugins/*/pom.xml
    changed versions:
        wicket-core                 10.0.0  -> 10.8.0
        spring-webmvc               6.1.7   -> 6.2.16
        cxf.version                 4.0.4   -> 4.1.8
```