### PR TITLE
NVDB-17016 - Explicitly compile with full annotation processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,7 @@
                     <version>3.13.0</version>
                     <configuration>
                         <release>21</release>
+                        <proc>full</proc>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
After updating to JDK 21 these messages appeared when compiling modules with annotation processing:

        [INFO]  Annotation processing is enabled because one or more processors were found
                on the class path. A future release of javac may disable annotation processing
                unless at least one processor is specified by name (-processor), or a search
                path is specified (--processor-path, --processor-module-path), or annotation
                processing is enabled explicitly (-proc:only, -proc:full).
                Use -Xlint:-options to suppress this message.
                Use -proc:none to disable annotation processing.

This patch explicitly adds proc=full to the compiler options.